### PR TITLE
Add support for parsing paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ Parse path params from URLs
 ```ts
 import { paths } from './paths';
 
+const values = paths.userPost.parse('/user/pomle/posts/24');
+
+console.log(values); // Prints {userId: "pomle", postId: 24}
+```
+
+Decode params already parsed
+
+```ts
+import { paths } from './paths';
+
 const values = paths.userPost.decode({
   userId: 'pomle',
   postId: '24',

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Create URLs
 ```ts
 import { paths } from './paths';
 
-const url = paths.userPost.url({
+const url = paths.userPost.build({
   userId: 'pomle',
   postId: 24,
 });

--- a/src/__tests__/path.test.ts
+++ b/src/__tests__/path.test.ts
@@ -11,7 +11,11 @@ describe('#createPath', () => {
       boolean: codec.boolean,
     });
 
-    it('encodes URL from params', () => {
+    it('builds path from params', () => {
+      expect(path.build(params)).toEqual('/text/fo%20o/2/0');
+    });
+
+    it('provides URL alias', () => {
       expect(path.url(params)).toEqual('/text/fo%20o/2/0');
     });
 

--- a/src/__tests__/path.test.ts
+++ b/src/__tests__/path.test.ts
@@ -5,14 +5,18 @@ describe('#createPath', () => {
   describe('#path', () => {
     const params = { text: 'fo o', number: 2, boolean: false };
 
-    const path = createPath('/:text/:number/:boolean', {
+    const path = createPath('/text/:text/:number/:boolean', {
       text: codec.string,
       number: codec.number,
       boolean: codec.boolean,
     });
 
     it('encodes URL from params', () => {
-      expect(path.url(params)).toEqual('/fo%20o/2/0');
+      expect(path.url(params)).toEqual('/text/fo%20o/2/0');
+    });
+
+    it('parse path string', () => {
+      expect(path.parse('/text/fo%20o/2/0')).toEqual(params);
     });
 
     it('creates typed params from URL', () => {
@@ -30,14 +34,16 @@ describe('#createPath', () => {
     });
 
     describe('appended path', () => {
-      const appendedPath = path.append('/:extra', {
+      const appendedPath = path.append('/extra/:extra', {
         extra: codec.string,
       });
 
       const appendedParams = { ...params, extra: '22bbee' };
 
       it('encodes URL from params', () => {
-        expect(appendedPath.url(appendedParams)).toEqual('/fo%20o/2/0/22bbee');
+        expect(appendedPath.url(appendedParams)).toEqual(
+          '/text/fo%20o/2/0/extra/22bbee',
+        );
       });
 
       it('creates typed params from URL', () => {

--- a/src/path.ts
+++ b/src/path.ts
@@ -47,6 +47,7 @@ export interface Path<Codec extends PathCodec> {
   path: string;
   codec: Codec;
   url(params: InputParams<Codec>): string;
+  build(params: InputParams<Codec>): string;
   parse(path: string): OutputParams<Codec>;
   encode(params: InputParams<Codec>): Params<Codec>;
   decode(params: Params<Codec>): OutputParams<Codec>;
@@ -89,11 +90,15 @@ export function createPath<Codec extends PathCodec>(
       return this.decode(params);
     },
 
-    url(params) {
+    build(params) {
       const encoded = this.encode(params);
       return Object.entries(encoded).reduce((pathName, [key, value]) => {
         return pathName.replace(':' + key, value);
       }, pathName);
+    },
+
+    url(params) {
+      return this.build(params);
     },
 
     append<AdditionalCodec extends PathCodec>(


### PR DESCRIPTION
This lib used to always be used together with third-party path parsers that provided param objects.

This PR builds that into this lib.